### PR TITLE
Fix: Add test runner configuration for .NET 10 SDK

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.101",
     "rollForward": "latestFeature"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
## Problem

With .NET 10 SDK, running `dot net test` fails with the following error;
> Testing with VSTest target is no longer supported by `Microsoft.Testing.Platform` on .NET 10 SDK and later.

This prevents users from running tests locally using `dotnet test` when using .NET 10 SDK.

Added test.runner as per Microsoft's instructions on : https://learn.microsoft.com/en-gb/dotnet/core/testing/unit-testing-with-dotnet-test