### PR TITLE
Add support for older dotnet versions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <Version>0.3.0</Version>
     <LangVersion>14</LangVersion>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,17 +1,32 @@
 <Project>
+
   <ItemGroup>
+    <PackageVersion Include="ProjectDefaults" Version="1.0.170" PrivateAssets="true" />
     <PackageVersion Include="CliFx" Version="2.3.6" />
     <PackageVersion Include="LocalDb" Version="23.1.6" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="27.0.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="180.10.0" />
     <PackageVersion Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.147.0" />
-    <PackageVersion Include="ProjectDefaults" Version="1.0.170" />
     <PackageVersion Include="TUnit" Version="1.11.28" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.TUnit" Version="31.9.4" />
   </ItemGroup>
+
+  <ItemGroup Condition = "'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition = "'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition = "'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
+  </ItemGroup>
+
 </Project>

--- a/src/EfToMermaid.Tests/EfToMermaid.Tests.csproj
+++ b/src/EfToMermaid.Tests/EfToMermaid.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>TestProject</RootNamespace>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
@@ -11,7 +10,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="ProjectDefaults" PrivateAssets="true" />
+    <PackageReference Include="ProjectDefaults" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="Verify.DiffPlex" />
     <PackageReference Include="Verify.TUnit" />

--- a/src/EfToMermaid/EfToMermaid.csproj
+++ b/src/EfToMermaid/EfToMermaid.csproj
@@ -1,13 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Description>Renders a Sql Server schema to a Mermaid diagram.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
-    <PackageReference Include="ProjectDefaults" PrivateAssets="true" />
+    <PackageReference Include="ProjectDefaults" />
     <Compile Include="..\Shared\*.cs"/>
   </ItemGroup>
 

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <ResolveAssemblyReferencesSilent>true</ResolveAssemblyReferencesSilent>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ProjectDefaults" PrivateAssets="true" />
   </ItemGroup>
+
 </Project>

--- a/src/SqlServerToMermaid.Tests/SqlServerToMermaid.Tests.csproj
+++ b/src/SqlServerToMermaid.Tests/SqlServerToMermaid.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>TestProject</RootNamespace>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>

--- a/src/SqlServerToMermaid/SqlServerToMermaid.csproj
+++ b/src/SqlServerToMermaid/SqlServerToMermaid.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Description>Renders a Sql Server schema to a Mermaid diagram.</Description>
   </PropertyGroup>
 

--- a/src/SqlServerToMermaidTool.Tests/SqlServerToMermaidTool.Tests.csproj
+++ b/src/SqlServerToMermaidTool.Tests/SqlServerToMermaidTool.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <SignAssembly>false</SignAssembly>

--- a/src/SqlServerToMermaidTool/SqlServerToMermaidTool.csproj
+++ b/src/SqlServerToMermaidTool/SqlServerToMermaidTool.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
I had some time on my hands and I also had a project that still is dotnet 8 that would like to use this. #7 

I could not find a pipeline file, so this is as far as I can go. There needs to be a `--framework` provided to the dotnet test command.