### PR TITLE
Include type length/precision in column types

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,29 +93,29 @@ var markdown = await SqlServerToMermaid.RenderMarkdown(sqlConnection);
 erDiagram
   Company["**Company**"] {
     int Id pk
-    nvarchar Name
-    varchar(nullable) TaxNumber
-    varchar(nullable) Phone
-    varchar(nullable) Email
+    nvarchar(200) Name
+    varchar(50)(nullable) TaxNumber
+    varchar(30)(nullable) Phone
+    varchar(255)(nullable) Email
     datetime2 CreatedAt
     datetime2(nullable) ModifiedAt
   }
   Customer["**Customer**"] {
     int Id pk
-    nvarchar FirstName
-    nvarchar LastName
-    varchar Email
-    varchar(nullable) Phone
+    nvarchar(100) FirstName
+    nvarchar(100) LastName
+    varchar(255) Email
+    varchar(30)(nullable) Phone
     int(nullable) CompanyId
     datetime2 CreatedAt
     datetime2(nullable) ModifiedAt
   }
   Employee["**Employee**"] {
     int Id pk
-    nvarchar FirstName
-    nvarchar LastName
-    varchar Email
-    varchar(nullable) Phone
+    nvarchar(100) FirstName
+    nvarchar(100) LastName
+    varchar(255) Email
+    varchar(30)(nullable) Phone
     date HireDate
     int CompanyId
     datetime2 CreatedAt
@@ -125,21 +125,21 @@ erDiagram
   Manager["**Manager**"] {
     int Id pk
     int EmployeeId
-    nvarchar Department
+    nvarchar(100) Department
     tinyint Level
     date StartDate
     date(nullable) EndDate
   }
   Order["**Order**"] {
     int Id pk
-    varchar OrderNumber
+    varchar(30) OrderNumber
     int CustomerId
     datetime2 OrderDate
-    varchar Status
-    decimal SubTotal
-    decimal Tax
-    decimal Total
-    nvarchar(nullable) Notes
+    varchar(20) Status
+    decimal(18,2) SubTotal
+    decimal(18,2) Tax
+    decimal(18,2) Total
+    nvarchar(1000)(nullable) Notes
     datetime2 CreatedAt
     datetime2(nullable) ModifiedAt
   }
@@ -148,16 +148,16 @@ erDiagram
     int OrderId
     int ProductId
     int Quantity
-    decimal UnitPrice
-    decimal Discount
-    decimal(nullable) LineTotal "computed"
+    decimal(18,2) UnitPrice
+    decimal(18,2) Discount
+    decimal(30,2)(nullable) LineTotal "computed"
   }
   Product["**Product**"] {
     int Id pk
-    varchar Sku
-    nvarchar Name
-    nvarchar(nullable) Description
-    decimal UnitPrice
+    varchar(50) Sku
+    nvarchar(200) Name
+    nvarchar(max)(nullable) Description
+    decimal(18,2) UnitPrice
     int StockQty
     bit IsActive
     datetime2 CreatedAt
@@ -357,9 +357,9 @@ var markdown = await EfToMermaid.RenderMarkdown(context.Model);
 erDiagram
   Customers["**Customers**"] {
     int CustomerId pk
-    nvarchar Name
-    nvarchar ShippingAddress_City
-    nvarchar ShippingAddress_Street
+    nvarchar(50) Name
+    nvarchar(50) ShippingAddress_City
+    nvarchar(100) ShippingAddress_Street
   }
   Orders["**Orders**"] {
     int OrderId pk

--- a/src/EfToMermaid.Tests/Tests.RenderMarkdown.verified.md
+++ b/src/EfToMermaid.Tests/Tests.RenderMarkdown.verified.md
@@ -3,9 +3,9 @@
 erDiagram
   Customers["**Customers**"] {
     int CustomerId pk
-    nvarchar Name
-    nvarchar ShippingAddress_City
-    nvarchar ShippingAddress_Street
+    nvarchar(50) Name
+    nvarchar(50) ShippingAddress_City
+    nvarchar(100) ShippingAddress_Street
   }
   Orders["**Orders**"] {
     int OrderId pk

--- a/src/EfToMermaid.Tests/Tests.WithComments.verified.md
+++ b/src/EfToMermaid.Tests/Tests.WithComments.verified.md
@@ -3,9 +3,9 @@
 erDiagram
   Customers["**Customers**: Core customer information"] {
     int CustomerId pk "Auto-generated identifier"
-    nvarchar Name "Customer full name"
-    nvarchar ShippingAddress_City
-    nvarchar ShippingAddress_Street
+    nvarchar(50) Name "Customer full name"
+    nvarchar(max) ShippingAddress_City
+    nvarchar(max) ShippingAddress_Street
   }
   Orders["**Orders**: Customer orders"] {
     int OrderId pk "Auto-generated identifier"

--- a/src/EfToMermaid.Tests/Tests.WithEscaping.verified.md
+++ b/src/EfToMermaid.Tests/Tests.WithEscaping.verified.md
@@ -3,9 +3,9 @@
 erDiagram
   Customers["**Customers**: Contains 'quotes' here"] {
     int CustomerId pk "The 'primary' key"
-    nvarchar Name
-    nvarchar ShippingAddress_City
-    nvarchar ShippingAddress_Street
+    nvarchar(50) Name
+    nvarchar(max) ShippingAddress_City
+    nvarchar(max) ShippingAddress_Street
   }
   Orders["**Orders**"] {
     int OrderId pk

--- a/src/EfToMermaid.Tests/Tests.WithNullable.verified.md
+++ b/src/EfToMermaid.Tests/Tests.WithNullable.verified.md
@@ -3,7 +3,7 @@
 erDiagram
   Customers["**Customers**"] {
     int CustomerId pk
-    nvarchar(nullable) Name
+    nvarchar(50)(nullable) Name
   }
   Orders["**Orders**"] {
     int OrderId pk

--- a/src/EfToMermaid.Tests/Tests.WithSchema.verified.md
+++ b/src/EfToMermaid.Tests/Tests.WithSchema.verified.md
@@ -3,9 +3,9 @@
 erDiagram
   sales_Customers["**sales_Customers**"] {
     int CustomerId pk
-    nvarchar Name
-    nvarchar ShippingAddress_City
-    nvarchar ShippingAddress_Street
+    nvarchar(50) Name
+    nvarchar(max) ShippingAddress_City
+    nvarchar(max) ShippingAddress_Street
   }
   sales_Orders["**sales_Orders**"] {
     int OrderId pk

--- a/src/EfToMermaid/SchemaReader.cs
+++ b/src/EfToMermaid/SchemaReader.cs
@@ -86,18 +86,34 @@ static class SchemaReader
         }
 
         token = token.Trim();
+
         var paren = token.IndexOf('(');
-        if (paren >= 0)
+        if (paren < 0)
         {
-            token = token[..paren];
+            return TrimAtSpace(token).ToLowerInvariant();
         }
 
-        var space = token.IndexOf(' ');
-        if (space >= 0)
+        var name = TrimAtSpace(token[..paren]).ToLowerInvariant();
+        var close = token.IndexOf(')', paren);
+        var arguments = close < 0 ? token[(paren + 1)..] : token[(paren + 1)..close];
+        // mermaid attribute types cannot contain whitespace
+        arguments = string.Join(',', arguments.Split(',').Select(_ => _.Trim()));
+        if (arguments.Length == 0)
         {
-            token = token[..space];
+            return name;
         }
 
-        return token.ToLowerInvariant();
+        return $"{name}({arguments.ToLowerInvariant()})";
+    }
+
+    static string TrimAtSpace(string value)
+    {
+        var space = value.IndexOf(' ');
+        if (space < 0)
+        {
+            return value;
+        }
+
+        return value[..space];
     }
 }

--- a/src/SqlServerToMermaid.Tests/FormatTypeTests.cs
+++ b/src/SqlServerToMermaid.Tests/FormatTypeTests.cs
@@ -1,18 +1,42 @@
 public class FormatTypeTests
 {
     [Test]
-    public async Task NVarCharMax_maps_to_nvarchar() =>
-        await Assert.That(SchemaReader.FormatType(new(SqlDataType.NVarCharMax))).IsEqualTo("nvarchar");
+    public async Task NVarCharMax_maps_to_nvarchar_max() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.NVarCharMax))).IsEqualTo("nvarchar(max)");
 
     [Test]
-    public async Task Decimal_maps_to_decimal() =>
-        await Assert.That(SchemaReader.FormatType(new(SqlDataType.Decimal))).IsEqualTo("decimal");
+    public async Task NVarChar_includes_length() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.NVarChar, 50))).IsEqualTo("nvarchar(50)");
 
     [Test]
-    public async Task DateTime2_maps_to_datetime2() =>
+    public async Task Char_includes_length() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.Char, 3))).IsEqualTo("char(3)");
+
+    [Test]
+    public async Task Decimal_uses_default_precision_and_scale() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.Decimal))).IsEqualTo("decimal(18,0)");
+
+    [Test]
+    public async Task Decimal_includes_precision_and_scale() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.Decimal, 18, 2))).IsEqualTo("decimal(18,2)");
+
+    [Test]
+    public async Task DateTime2_omits_scale() =>
         await Assert.That(SchemaReader.FormatType(new(SqlDataType.DateTime2))).IsEqualTo("datetime2");
 
     [Test]
-    public async Task VarBinaryMax_maps_to_varbinary() =>
-        await Assert.That(SchemaReader.FormatType(new(SqlDataType.VarBinaryMax))).IsEqualTo("varbinary");
+    public async Task DateTime2_with_explicit_scale_omits_scale() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.DateTime2, 3))).IsEqualTo("datetime2");
+
+    [Test]
+    public async Task Float_omits_precision() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.Float))).IsEqualTo("float");
+
+    [Test]
+    public async Task Float_with_explicit_precision_omits_precision() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.Float, 24))).IsEqualTo("float");
+
+    [Test]
+    public async Task VarBinaryMax_maps_to_varbinary_max() =>
+        await Assert.That(SchemaReader.FormatType(new(SqlDataType.VarBinaryMax))).IsEqualTo("varbinary(max)");
 }

--- a/src/SqlServerToMermaid.Tests/Tests.CustomSchema.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.CustomSchema.verified.md
@@ -2,7 +2,7 @@
 erDiagram
   sales_Customers["**sales_Customers**"] {
     int CustomerId pk
-    nvarchar Name
+    nvarchar(50) Name
   }
   sales_Orders["**sales_Orders**"] {
     int OrderId pk

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdown.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdown.verified.md
@@ -3,29 +3,29 @@
 erDiagram
   Company["**Company**"] {
     int Id pk
-    nvarchar Name
-    varchar(nullable) TaxNumber
-    varchar(nullable) Phone
-    varchar(nullable) Email
+    nvarchar(200) Name
+    varchar(50)(nullable) TaxNumber
+    varchar(30)(nullable) Phone
+    varchar(255)(nullable) Email
     datetime2 CreatedAt
     datetime2(nullable) ModifiedAt
   }
   Customer["**Customer**"] {
     int Id pk
-    nvarchar FirstName
-    nvarchar LastName
-    varchar Email
-    varchar(nullable) Phone
+    nvarchar(100) FirstName
+    nvarchar(100) LastName
+    varchar(255) Email
+    varchar(30)(nullable) Phone
     int(nullable) CompanyId
     datetime2 CreatedAt
     datetime2(nullable) ModifiedAt
   }
   Employee["**Employee**"] {
     int Id pk
-    nvarchar FirstName
-    nvarchar LastName
-    varchar Email
-    varchar(nullable) Phone
+    nvarchar(100) FirstName
+    nvarchar(100) LastName
+    varchar(255) Email
+    varchar(30)(nullable) Phone
     date HireDate
     int CompanyId
     datetime2 CreatedAt
@@ -35,21 +35,21 @@ erDiagram
   Manager["**Manager**"] {
     int Id pk
     int EmployeeId
-    nvarchar Department
+    nvarchar(100) Department
     tinyint Level
     date StartDate
     date(nullable) EndDate
   }
   Order["**Order**"] {
     int Id pk
-    varchar OrderNumber
+    varchar(30) OrderNumber
     int CustomerId
     datetime2 OrderDate
-    varchar Status
-    decimal SubTotal
-    decimal Tax
-    decimal Total
-    nvarchar(nullable) Notes
+    varchar(20) Status
+    decimal(18,2) SubTotal
+    decimal(18,2) Tax
+    decimal(18,2) Total
+    nvarchar(1000)(nullable) Notes
     datetime2 CreatedAt
     datetime2(nullable) ModifiedAt
   }
@@ -58,16 +58,16 @@ erDiagram
     int OrderId
     int ProductId
     int Quantity
-    decimal UnitPrice
-    decimal Discount
-    decimal(nullable) LineTotal "computed"
+    decimal(18,2) UnitPrice
+    decimal(18,2) Discount
+    decimal(30,2)(nullable) LineTotal "computed"
   }
   Product["**Product**"] {
     int Id pk
-    varchar Sku
-    nvarchar Name
-    nvarchar(nullable) Description
-    decimal UnitPrice
+    varchar(50) Sku
+    nvarchar(200) Name
+    nvarchar(max)(nullable) Description
+    decimal(18,2) UnitPrice
     int StockQty
     bit IsActive
     datetime2 CreatedAt

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScript.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScript.verified.md
@@ -2,16 +2,16 @@
 erDiagram
   Company["**Company**"] {
     int Id
-    nvarchar Name
+    nvarchar(200) Name
     datetime2 CreatedAt
   }
   Employee["**Employee**"] {
     int Id
-    nvarchar FirstName
-    nvarchar LastName
+    nvarchar(100) FirstName
+    nvarchar(100) LastName
     int CompanyId
-    decimal Salary
-    decimal Bonus
+    decimal(18,2) Salary
+    decimal(18,2) Bonus
     unknown(nullable) TotalPay "computed"
   }
   Company ||--o{ Employee : "FK_Employee_Company"

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptIgnoresIrrelevantExec.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptIgnoresIrrelevantExec.verified.md
@@ -2,6 +2,6 @@
 erDiagram
   hr_Employees["**hr_Employees**: Employee records"] {
     int Id
-    nvarchar Name
+    nvarchar(100) Name
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithAlterTableAddColumn.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithAlterTableAddColumn.verified.md
@@ -2,7 +2,7 @@
 erDiagram
   Items["**Items**"] {
     int Id
-    nvarchar Name
+    nvarchar(100) Name
   }
   NewTable["**NewTable**"] {
     int(nullable) Value

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithCommentNoSchema.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithCommentNoSchema.verified.md
@@ -2,6 +2,6 @@
 erDiagram
   Customers["**Customers**: Main customer table"] {
     int Id "Unique identifier"
-    nvarchar Name
+    nvarchar(100) Name
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithComments.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithComments.verified.md
@@ -2,7 +2,7 @@
 erDiagram
   Customers["**Customers**: Core customer information"] {
     int CustomerId "Auto-generated identifier"
-    nvarchar Name "Customer full name"
-    varchar(nullable) Email
+    nvarchar(100) Name "Customer full name"
+    varchar(255)(nullable) Email
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithComputedAndComment.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithComputedAndComment.verified.md
@@ -2,8 +2,8 @@
 erDiagram
   Employee["**Employee**"] {
     int Id
-    decimal Salary
-    decimal Bonus
+    decimal(18,2) Salary
+    decimal(18,2) Bonus
     unknown(nullable) TotalPay "computed: Sum of salary and bonus"
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithEscaping.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithEscaping.verified.md
@@ -2,6 +2,6 @@
 erDiagram
   Customers["**Customers**: Contains 'quotes' here"] {
     int CustomerId "The 'primary' key"
-    nvarchar Name
+    nvarchar(100) Name
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithNoPrimaryKey.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithNoPrimaryKey.verified.md
@@ -2,7 +2,7 @@
 erDiagram
   AuditLog["**AuditLog**"] {
     datetime2 Timestamp
-    nvarchar Action
-    nvarchar(nullable) Detail
+    nvarchar(100) Action
+    nvarchar(500)(nullable) Detail
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithSchema.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownFromScriptWithSchema.verified.md
@@ -2,7 +2,7 @@
 erDiagram
   sales_Customers["**sales_Customers**"] {
     int CustomerId
-    nvarchar Name
+    nvarchar(50) Name
   }
   sales_Orders["**sales_Orders**"] {
     int OrderId

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownWithComments.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownWithComments.verified.md
@@ -3,7 +3,7 @@
 erDiagram
   Customers["**Customers**: Core customer information"] {
     int CustomerId pk "Auto-generated identifier"
-    nvarchar Name "Customer full name"
-    varchar(nullable) Email
+    nvarchar(100) Name "Customer full name"
+    varchar(255)(nullable) Email
   }
 ```

--- a/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownWithEscaping.verified.md
+++ b/src/SqlServerToMermaid.Tests/Tests.RenderMarkdownWithEscaping.verified.md
@@ -3,6 +3,6 @@
 erDiagram
   Customers["**Customers**: Contains 'quotes' here"] {
     int CustomerId pk "The 'primary' key"
-    nvarchar Name
+    nvarchar(100) Name
   }
 ```

--- a/src/SqlServerToMermaid/SchemaReader.cs
+++ b/src/SqlServerToMermaid/SchemaReader.cs
@@ -91,14 +91,56 @@ static class SchemaReader
 
     public static string FormatType(DataType dataType)
     {
-        // Mermaid ER diagram type token must be a simple word (no parentheses); normalize SMO types accordingly.
+        // Mermaid ER diagram type tokens cannot contain whitespace, so no space after the comma in eg decimal(18,2)
         var token = dataType.SqlDataType.ToString();
-        if (token.EndsWith("Max", StringComparison.Ordinal))
+        var isMax = token.EndsWith("Max", StringComparison.Ordinal);
+        if (isMax)
         {
             token = token[..^3];
         }
 
         token = token.ToLowerInvariant();
-        return token is "userdefineddatatype" or "none" ? dataType.Name : token;
+        if (token is "userdefineddatatype" or "none")
+        {
+            return dataType.Name;
+        }
+
+        if (isMax)
+        {
+            return $"{token}(max)";
+        }
+
+        return token + FormatArguments(dataType);
+    }
+
+    static string FormatArguments(DataType dataType)
+    {
+        switch (dataType.SqlDataType)
+        {
+            case SqlDataType.Char:
+            case SqlDataType.NChar:
+            case SqlDataType.VarChar:
+            case SqlDataType.NVarChar:
+            case SqlDataType.Binary:
+            case SqlDataType.VarBinary:
+                if (dataType.MaximumLength > 0)
+                {
+                    return $"({dataType.MaximumLength})";
+                }
+
+                return "";
+            case SqlDataType.Decimal:
+            case SqlDataType.Numeric:
+                if (dataType.NumericPrecision > 0)
+                {
+                    return $"({dataType.NumericPrecision},{dataType.NumericScale})";
+                }
+
+                return "";
+            // float precision, and fractional seconds scale for datetime2/datetimeoffset/time, are
+            // deliberately omitted. They are noise in a diagram
+            default:
+                return "";
+        }
     }
 }

--- a/src/SqlServerToMermaid/ScriptParser.cs
+++ b/src/SqlServerToMermaid/ScriptParser.cs
@@ -227,10 +227,23 @@ static class ScriptParser
 
         return dataType switch
         {
-            SqlDataTypeReference sqlType => sqlType.SqlDataTypeOption.ToString().ToLowerInvariant(),
-            UserDataTypeReference userType => userType.Name.BaseIdentifier.Value.ToLowerInvariant(),
+            SqlDataTypeReference sqlType => sqlType.SqlDataTypeOption.ToString().ToLowerInvariant() + FormatParameters(sqlType),
+            UserDataTypeReference userType => userType.Name.BaseIdentifier.Value.ToLowerInvariant() + FormatParameters(userType),
             _ => "unknown"
         };
+    }
+
+    static string FormatParameters(ParameterizedDataTypeReference dataType)
+    {
+        if (dataType.Parameters.Count == 0)
+        {
+            return "";
+        }
+
+        // Mermaid ER diagram type tokens cannot contain whitespace, so no space after the comma in eg decimal(18,2)
+        var parameters = dataType.Parameters
+            .Select(_ => _ is MaxLiteral ? "max" : _.Value.ToLowerInvariant());
+        return $"({string.Join(',', parameters)})";
     }
 
     static bool IsNullable(ColumnDefinition columnDef)

--- a/src/SqlServerToMermaidTool.Tests/IntegrationTests.ConnectionString_ToMarkdown.verified.md
+++ b/src/SqlServerToMermaidTool.Tests/IntegrationTests.ConnectionString_ToMarkdown.verified.md
@@ -2,11 +2,11 @@
 erDiagram
   Company["**Company**"] {
     int Id pk
-    nvarchar Name
+    nvarchar(200) Name
   }
   Employee["**Employee**"] {
     int Id pk
-    nvarchar FirstName
+    nvarchar(100) FirstName
     int CompanyId
   }
   Company ||--o{ Employee : "FK_Employee_Company"

--- a/src/SqlServerToMermaidTool.Tests/IntegrationTests.ConnectionString_ToMermaid.verified.mmd
+++ b/src/SqlServerToMermaidTool.Tests/IntegrationTests.ConnectionString_ToMermaid.verified.mmd
@@ -1,5 +1,5 @@
 ﻿erDiagram
   Users["**Users**"] {
     int Id pk
-    nvarchar Name
+    nvarchar(100) Name
   }

--- a/src/SqlServerToMermaidTool.Tests/IntegrationTests.RawSql_ToMarkdown.verified.md
+++ b/src/SqlServerToMermaidTool.Tests/IntegrationTests.RawSql_ToMarkdown.verified.md
@@ -2,6 +2,6 @@
 erDiagram
   Orders["**Orders**"] {
     int Id
-    decimal Total
+    decimal(18,2) Total
   }
 ```

--- a/src/SqlServerToMermaidTool.Tests/IntegrationTests.SqlFile_ToMarkdown.verified.md
+++ b/src/SqlServerToMermaidTool.Tests/IntegrationTests.SqlFile_ToMarkdown.verified.md
@@ -2,7 +2,7 @@
 erDiagram
   Products["**Products**"] {
     int Id
-    nvarchar Name
-    decimal Price
+    nvarchar(200) Name
+    decimal(18,2) Price
   }
 ```


### PR DESCRIPTION
Fixes #20

nvarchar(50), nvarchar(max), decimal(18,2) etc are now rendered instead of a bare nvarchar/decimal. Applies to all three schema sources: EF store types, SMO, and script parsing.

Arguments are normalized to contain no whitespace, since a mermaid ER attribute type token allows parentheses and commas but not spaces.

float precision, and fractional seconds scale for datetime2/datetimeoffset/ time, are omitted. SMO always reports them, so including them would add noise to every diagram.